### PR TITLE
file support for word payloads

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,10 +2,12 @@ package alterx
 
 import (
 	"os"
+	"strings"
 
 	_ "embed"
 
 	"github.com/projectdiscovery/gologger"
+	fileutil "github.com/projectdiscovery/utils/file"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,6 +32,21 @@ func NewConfig(filePath string) (*Config, error) {
 	if err = yaml.Unmarshal(bin, &cfg); err != nil {
 		return nil, err
 	}
+
+	var words []string
+	for _, p := range cfg.Payloads["word"] {
+		if !fileutil.FileExists(p) {
+			words = append(words, p)
+		} else {
+			wordBytes, err := os.ReadFile(p)
+			if err != nil {
+				gologger.Error().Msgf("failed to read wordlist from %v got %v", p, err)
+				continue
+			}
+			words = append(words, strings.Fields(string(wordBytes))...)
+		}
+	}
+	cfg.Payloads["word"] = words
 	return &cfg, nil
 }
 


### PR DESCRIPTION
This PR adds file support for word payloads. Closes #13.

Example:

cmd:
```
go run main.go -l projectdiscovery.io -ac test.yaml 
```

output:
```

   ___   ____          _  __
  / _ | / / /____ ____| |/_/
 / __ |/ / __/ -_) __/>  <  
/_/ |_/_/\__/\__/_/ /_/|_|                               

                projectdiscovery.io

[INF] Current alterx version v0.0.1 (latest)
backup.projectdiscovery.io
raw.projectdiscovery.io
oauth2.projectdiscovery.io
acc.projectdiscovery.io
storage.projectdiscovery.io
www2.projectdiscovery.io
cloud.projectdiscovery.io
live.projectdiscovery.io
dmz.projectdiscovery.io
s3.projectdiscovery.io
internal.projectdiscovery.io
conf.projectdiscovery.io
proxy.projectdiscovery.io
login.projectdiscovery.io
vpn.projectdiscovery.io
payment.projectdiscovery.io
docs.projectdiscovery.io
developer.projectdiscovery.io
beta.projectdiscovery.io
lab.projectdiscovery.io
media.projectdiscovery.io
logs.projectdiscovery.io
info.projectdiscovery.io
ldap.projectdiscovery.io
administrator.projectdiscovery.io
v2.projectdiscovery.io
staging.projectdiscovery.io
dashboard.projectdiscovery.io
s1.projectdiscovery.io
image.projectdiscovery.io
app.projectdiscovery.io
role.projectdiscovery.io
client.projectdiscovery.io
data.projectdiscovery.io
k8s.projectdiscovery.io
test.projectdiscovery.io
backend.projectdiscovery.io
v1.projectdiscovery.io
mta-sts.projectdiscovery.io
stats.projectdiscovery.io
mail.projectdiscovery.io
engineering.projectdiscovery.io
mssql.projectdiscovery.io
server.projectdiscovery.io
www1.projectdiscovery.io
origin.projectdiscovery.io
qa.projectdiscovery.io
admin.projectdiscovery.io
corp.projectdiscovery.io
shopify.projectdiscovery.io
atlas.projectdiscovery.io
wp.projectdiscovery.io
blog.projectdiscovery.io
review.projectdiscovery.io
public.projectdiscovery.io
log.projectdiscovery.io
monitor.projectdiscovery.io
access.projectdiscovery.io
build.projectdiscovery.io
stage.projectdiscovery.io
prod.projectdiscovery.io
compute.projectdiscovery.io
drupal.projectdiscovery.io
plugins.projectdiscovery.io
stripe.projectdiscovery.io
private.projectdiscovery.io
dev.projectdiscovery.io
eng.projectdiscovery.io
www.projectdiscovery.io
core.projectdiscovery.io
ads.projectdiscovery.io
builds.projectdiscovery.io
web.projectdiscovery.io
search.projectdiscovery.io
cdn.projectdiscovery.io
faq.projectdiscovery.io
shop.projectdiscovery.io
grafana.projectdiscovery.io
cms.projectdiscovery.io
my.projectdiscovery.io
wordpress.projectdiscovery.io
oauth.projectdiscovery.io
temp.projectdiscovery.io
prometheus.projectdiscovery.io
manager.projectdiscovery.io
code.projectdiscovery.io
netlify.projectdiscovery.io
local.projectdiscovery.io
partner.projectdiscovery.io
db.projectdiscovery.io
office.projectdiscovery.io
assets.projectdiscovery.io
developers.projectdiscovery.io
api.projectdiscovery.io
mobile.projectdiscovery.io
blogs.projectdiscovery.io
cms1.projectdiscovery.io
ir.projectdiscovery.io
content.projectdiscovery.io
o1.projectdiscovery.io
service.projectdiscovery.io
market.projectdiscovery.io
careers.projectdiscovery.io
asset.projectdiscovery.io
tech.projectdiscovery.io
final.projectdiscovery.io
promotion.projectdiscovery.io
legacy.projectdiscovery.io
forum.projectdiscovery.io
mysql.projectdiscovery.io
pay.projectdiscovery.io
[INF] Generated 111 permutations in 0.0004s
```

permutation config file, test.yaml:
```
patterns:
  - "{{word}}-{{sub}}.{{suffix}}" # dev-api
  - "{{sub}}-{{word}}.{{suffix}}" # api-dev
  - "{{word}}.{{sub}}.{{suffix}}"
  - "{{sub}}.{{word}}.{{suffix}}"
  - "{{sub}}{{number}}.{{suffix}}"
  - "{{word}}.{{suffix}}"
  - "{{sub}}{{word}}.{{suffix}}"
  - "{{region}}.{{sub}}.{{suffix}}"

payloads:
  word:
    - "netlify"
    - "storage"
    - wordlist.txt

  region:
    - "us-east-1"
    - "eu-central-1"

  number:
    - "1"
    - "2"

```

wordlist.txt:
```
api
k8s
v1
v2
origin
raw
stage
test
qa
web
prod
service
grafana
beta
admin
staging
wordpress
wp
dev
app
mta-sts
tech
private
public
login
role
backend
cloud
internal
mail
oauth
oauth2
vpn
lab
local
live
data
mobile
search
stats
final
ldap
media
docs
eng
engineering
market
compute
cdn
acc
access
backup
blogs
blog
careers
client
cms
cms1
conf
dmz
drupal
corp
faq
ir
legacy
log
logs
dashboard
monitor
mysql
mssql
db
partner
payment
pay
office
plugins
shop
prometheus
stripe
forum
manager
server
core
content
ads
shopify
o1
s1
s3
promotion
temp
my
proxy
asset
assets
atlas
build
builds
code
info
image
review
developers
developer
administrator
www
www1
www2
```