### PR TITLE
Add the sld (second-level domain) variable to obtain the domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Almost all popular subdomain permutation tools have hardcoded patterns and when 
 ### Advanced Variables
 
 ```yaml
+{{main}}  :  domain  (ex for api.scanme.sh => {{main}} is scanme)
 {{root}}  :  also known as eTLD+1 i.e only root domain (ex for api.scanme.sh => {{root}} is scanme.sh)
 {{subN}}  :  here N is an integer (ex {{sub1}} , {{sub2}} etc) .
 
@@ -124,6 +125,7 @@ Almost all popular subdomain permutation tools have hardcoded patterns and when 
 
 | Variable | api.scanme.sh | admin.dev.scanme.sh | cloud.scanme.co.uk |
 | -------- | ------------- | ------------------- | ------------------ |
+| `{{main}}` | `scanme`      | `scanme`            | `scanme`         |
 | `{{root}}` | `scanme.sh`   | `scanme.sh`         | `scanme.co.uk`   |
 | `{{sub1}}` | `-`           | `dev`               | `-`              |
 | `{{sub2}}` | `-`           | `-`                 | `-`              |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Almost all popular subdomain permutation tools have hardcoded patterns and when 
 ### Advanced Variables
 
 ```yaml
-{{main}}  :  domain  (ex for api.scanme.sh => {{main}} is scanme)
+{{sld}}  :  domain  (ex for api.scanme.sh => {{sld}} is scanme)
 {{root}}  :  also known as eTLD+1 i.e only root domain (ex for api.scanme.sh => {{root}} is scanme.sh)
 {{subN}}  :  here N is an integer (ex {{sub1}} , {{sub2}} etc) .
 
@@ -125,7 +125,7 @@ Almost all popular subdomain permutation tools have hardcoded patterns and when 
 
 | Variable | api.scanme.sh | admin.dev.scanme.sh | cloud.scanme.co.uk |
 | -------- | ------------- | ------------------- | ------------------ |
-| `{{main}}` | `scanme`      | `scanme`            | `scanme`         |
+| `{{sld}}` | `scanme`      | `scanme`            | `scanme`         |
 | `{{root}}` | `scanme.sh`   | `scanme.sh`         | `scanme.co.uk`   |
 | `{{sub1}}` | `-`           | `dev`               | `-`              |
 | `{{sub2}}` | `-`           | `-`                 | `-`              |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ UPDATE:
 
 ## Why `alterx` ??
 
-what makes `alterx` different from any other subdomain permutation tools like `goaltdns` is its `scripting` feature . alterx takes patterns as input and generates subdomain permutation wordlist based on that pattern similar to what [nuclei](https://github.com/projectdiscovery/nuclei) does with [fuzzing-templates](https://github.com/projectdiscovery/fuzzing-templates) . 
+what makes `alterx` different from any other subdomain permutation tools like `goaltdns` is its `scripting` feature . alterx takes patterns as input and generates subdomain permutation wordlist based on that pattern similar to what [nuclei](https://github.com/projectdiscovery/nuclei) does with [fuzzing-templates](https://github.com/projectdiscovery/fuzzing-templates) .
 
 What makes `Active Subdomain Enumeration` difficult is the probability of finding a domain that actually exists. If finding possible subdomains is represented on a scale it should look something like
 
@@ -96,7 +96,7 @@ Almost all popular subdomain permutation tools have hardcoded patterns and when 
 `alterx` uses variable-like syntax similar to nuclei-templates. One can write their own patterns using these variables . when domains are passed as input `alterx` evaluates input and extracts variables from it .
 
 ### Basic / Common Variables
-  
+
 ```yaml
 {{sub}}     :  subdomain prefix or left most part of a subdomain
 {{suffix}}  :  everything except {{sub}} in subdomain name is suffix
@@ -114,7 +114,7 @@ Almost all popular subdomain permutation tools have hardcoded patterns and when 
 ### Advanced Variables
 
 ```yaml
-{{sld}}  :  domain  (ex for api.scanme.sh => {{sld}} is scanme)
+{{sld}}  :   second-level domain  (ex for api.scanme.sh => {{sld}} is scanme)
 {{root}}  :  also known as eTLD+1 i.e only root domain (ex for api.scanme.sh => {{root}} is scanme.sh)
 {{subN}}  :  here N is an integer (ex {{sub1}} , {{sub2}} etc) .
 
@@ -161,12 +161,12 @@ An example of running alterx on existing list of passive subdomains of `tesla.co
 ```console
 $ chaos -d tesla.com | alterx | dnsx
 
- 
+
 
    ___   ____          _  __
   / _ | / / /____ ____| |/_/
- / __ |/ / __/ -_) __/>  <  
-/_/ |_/_/\__/\__/_/ /_/|_|              
+ / __ |/ / __/ -_) __/>  <
+/_/ |_/_/\__/\__/_/ /_/|_|
 
       projectdiscovery.io
 
@@ -190,23 +190,23 @@ $ chaos -d tesla.com | alterx -enrich
 
    ___   ____          _  __
   / _ | / / /____ ____| |/_/
- / __ |/ / __/ -_) __/>  <  
-/_/ |_/_/\__/\__/_/ /_/|_|              
+ / __ |/ / __/ -_) __/>  <
+/_/ |_/_/\__/\__/_/ /_/|_|
 
       projectdiscovery.io
 
 [INF] Generated 662010 permutations in 3.9989s
 ```
 
-You can alter the default patterns at run time using `-pattern` CLI option. 
+You can alter the default patterns at run time using `-pattern` CLI option.
 
 ```console
 $ chaos -d tesla.com | alterx -enrich -p '{{word}}-{{suffix}}'
 
    ___   ____          _  __
   / _ | / / /____ ____| |/_/
- / __ |/ / __/ -_) __/>  <  
-/_/ |_/_/\__/\__/_/ /_/|_|              
+ / __ |/ / __/ -_) __/>  <
+/_/ |_/_/\__/\__/_/ /_/|_|
 
       projectdiscovery.io
 
@@ -220,8 +220,8 @@ $ alterx -list tesla.txt -enrich -p '{{word}}-{{year}}.{{suffix}}' -pp word=keyw
 
    ___   ____          _  __
   / _ | / / /____ ____| |/_/
- / __ |/ / __/ -_) __/>  <  
-/_/ |_/_/\__/\__/_/ /_/|_|              
+ / __ |/ / __/ -_) __/>  <
+/_/ |_/_/\__/\__/_/ /_/|_|
 
       projectdiscovery.io
 

--- a/inputs.go
+++ b/inputs.go
@@ -14,7 +14,7 @@ import (
 type Input struct {
 	TLD        string   // only TLD (right most part of subdomain) ex: `.uk`
 	ETLD       string   // Simply put public suffix (ex: co.uk)
-	Main       string   // Main of Subdomain (ex: scanme)
+	SLD        string   // SLD of Subdomain (ex: scanme)
 	Root       string   // Root Domain (eTLD+1) of Subdomain
 	Sub        string   // Sub or LeftMost prefix of subdomain
 	Suffix     string   // suffix is everything except `Sub` (Note: if domain is not multilevel Suffix==Root)
@@ -26,7 +26,7 @@ func (i *Input) GetMap() map[string]interface{} {
 	m := map[string]interface{}{
 		"tld":    i.TLD,
 		"etld":   i.ETLD,
-		"main":   i.Main,
+		"sld":   i.SLD,
 		"root":   i.Root,
 		"sub":    i.Sub,
 		"suffix": i.Suffix,
@@ -78,9 +78,9 @@ func NewInput(inputURL string) (*Input, error) {
 	}
 	ivar.Root = rootDomain
 	if ivar.ETLD != "" {
-		ivar.Main = strings.TrimSuffix(rootDomain, "."+ivar.ETLD)
+		ivar.SLD = strings.TrimSuffix(rootDomain, "."+ivar.ETLD)
 	} else {
-		ivar.Main = strings.TrimSuffix(rootDomain, "."+ivar.TLD)
+		ivar.SLD = strings.TrimSuffix(rootDomain, "."+ivar.TLD)
 	}
 	// anything before root domain is subdomain
 	subdomainPrefix := strings.TrimSuffix(URL.Hostname(), rootDomain)

--- a/inputs.go
+++ b/inputs.go
@@ -14,6 +14,7 @@ import (
 type Input struct {
 	TLD        string   // only TLD (right most part of subdomain) ex: `.uk`
 	ETLD       string   // Simply put public suffix (ex: co.uk)
+	Main       string   // Main of Subdomain (ex: scanme)
 	Root       string   // Root Domain (eTLD+1) of Subdomain
 	Sub        string   // Sub or LeftMost prefix of subdomain
 	Suffix     string   // suffix is everything except `Sub` (Note: if domain is not multilevel Suffix==Root)
@@ -25,6 +26,7 @@ func (i *Input) GetMap() map[string]interface{} {
 	m := map[string]interface{}{
 		"tld":    i.TLD,
 		"etld":   i.ETLD,
+		"main":   i.Main,
 		"root":   i.Root,
 		"sub":    i.Sub,
 		"suffix": i.Suffix,
@@ -75,6 +77,11 @@ func NewInput(inputURL string) (*Input, error) {
 		return ivar, nil
 	}
 	ivar.Root = rootDomain
+	if ivar.ETLD != "" {
+		ivar.Main = strings.TrimSuffix(rootDomain, "."+ivar.ETLD)
+	} else {
+		ivar.Main = strings.TrimSuffix(rootDomain, "."+ivar.TLD)
+	}
 	// anything before root domain is subdomain
 	subdomainPrefix := strings.TrimSuffix(URL.Hostname(), rootDomain)
 	subdomainPrefix = strings.TrimSuffix(subdomainPrefix, ".")

--- a/inputs.go
+++ b/inputs.go
@@ -14,7 +14,7 @@ import (
 type Input struct {
 	TLD        string   // only TLD (right most part of subdomain) ex: `.uk`
 	ETLD       string   // Simply put public suffix (ex: co.uk)
-	SLD        string   // SLD of Subdomain (ex: scanme)
+	SLD        string   // Second-level domain (ex: scanme)
 	Root       string   // Root Domain (eTLD+1) of Subdomain
 	Sub        string   // Sub or LeftMost prefix of subdomain
 	Suffix     string   // suffix is everything except `Sub` (Note: if domain is not multilevel Suffix==Root)
@@ -26,7 +26,7 @@ func (i *Input) GetMap() map[string]interface{} {
 	m := map[string]interface{}{
 		"tld":    i.TLD,
 		"etld":   i.ETLD,
-		"sld":   i.SLD,
+		"sld":    i.SLD,
 		"root":   i.Root,
 		"sub":    i.Sub,
 		"suffix": i.Suffix,

--- a/inputs_test.go
+++ b/inputs_test.go
@@ -11,7 +11,7 @@ func TestInput(t *testing.T) {
 	expected := &Input{
 		TLD:    "uk",
 		ETLD:   "co.uk",
-		Main:   "scanme",
+		SLD:    "scanme",
 		Root:   "scanme.co.uk",
 		Suffix: "scanme.co.uk",
 		Sub:    "",
@@ -28,11 +28,11 @@ func TestInputSub(t *testing.T) {
 		url      string
 		expected *Input
 	}{
-		{url: "something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Main: "scanme", Root: "scanme.sh", Sub: "something", Suffix: "scanme.sh"}},
-		{url: "nested.something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Main: "scanme", Root: "scanme.sh", Sub: "nested", Suffix: "something.scanme.sh", MultiLevel: []string{"something"}}},
-		{url: "nested.multilevel.scanme.co.uk", expected: &Input{TLD: "uk", ETLD: "co.uk", Main: "scanme", Root: "scanme.co.uk", Sub: "nested", Suffix: "multilevel.scanme.co.uk", MultiLevel: []string{"multilevel"}}},
-		{url: "sub.level1.level2.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Main: "scanme", Root: "scanme.sh", Sub: "sub", Suffix: "level1.level2.scanme.sh", MultiLevel: []string{"level1", "level2"}}},
-		{url: "scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Sub: "", Suffix: "scanme.sh", Main: "scanme", Root: "scanme.sh"}},
+		{url: "something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", SLD: "scanme", Root: "scanme.sh", Sub: "something", Suffix: "scanme.sh"}},
+		{url: "nested.something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", SLD: "scanme", Root: "scanme.sh", Sub: "nested", Suffix: "something.scanme.sh", MultiLevel: []string{"something"}}},
+		{url: "nested.multilevel.scanme.co.uk", expected: &Input{TLD: "uk", ETLD: "co.uk", SLD: "scanme", Root: "scanme.co.uk", Sub: "nested", Suffix: "multilevel.scanme.co.uk", MultiLevel: []string{"multilevel"}}},
+		{url: "sub.level1.level2.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", SLD: "scanme", Root: "scanme.sh", Sub: "sub", Suffix: "level1.level2.scanme.sh", MultiLevel: []string{"level1", "level2"}}},
+		{url: "scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Sub: "", Suffix: "scanme.sh", SLD: "scanme", Root: "scanme.sh"}},
 	}
 	for _, v := range testcases {
 		got, err := NewInput(v.url)

--- a/inputs_test.go
+++ b/inputs_test.go
@@ -11,6 +11,7 @@ func TestInput(t *testing.T) {
 	expected := &Input{
 		TLD:    "uk",
 		ETLD:   "co.uk",
+		Main:   "scanme",
 		Root:   "scanme.co.uk",
 		Suffix: "scanme.co.uk",
 		Sub:    "",
@@ -27,11 +28,11 @@ func TestInputSub(t *testing.T) {
 		url      string
 		expected *Input
 	}{
-		{url: "something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Root: "scanme.sh", Sub: "something", Suffix: "scanme.sh"}},
-		{url: "nested.something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Root: "scanme.sh", Sub: "nested", Suffix: "something.scanme.sh", MultiLevel: []string{"something"}}},
-		{url: "nested.multilevel.scanme.co.uk", expected: &Input{TLD: "uk", ETLD: "co.uk", Root: "scanme.co.uk", Sub: "nested", Suffix: "multilevel.scanme.co.uk", MultiLevel: []string{"multilevel"}}},
-		{url: "sub.level1.level2.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Root: "scanme.sh", Sub: "sub", Suffix: "level1.level2.scanme.sh", MultiLevel: []string{"level1", "level2"}}},
-		{url: "scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Sub: "", Suffix: "scanme.sh", Root: "scanme.sh"}},
+		{url: "something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Main: "scanme", Root: "scanme.sh", Sub: "something", Suffix: "scanme.sh"}},
+		{url: "nested.something.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Main: "scanme", Root: "scanme.sh", Sub: "nested", Suffix: "something.scanme.sh", MultiLevel: []string{"something"}}},
+		{url: "nested.multilevel.scanme.co.uk", expected: &Input{TLD: "uk", ETLD: "co.uk", Main: "scanme", Root: "scanme.co.uk", Sub: "nested", Suffix: "multilevel.scanme.co.uk", MultiLevel: []string{"multilevel"}}},
+		{url: "sub.level1.level2.scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Main: "scanme", Root: "scanme.sh", Sub: "sub", Suffix: "level1.level2.scanme.sh", MultiLevel: []string{"level1", "level2"}}},
+		{url: "scanme.sh", expected: &Input{TLD: "sh", ETLD: "", Sub: "", Suffix: "scanme.sh", Main: "scanme", Root: "scanme.sh"}},
 	}
 	for _, v := range testcases {
 		got, err := NewInput(v.url)


### PR DESCRIPTION
- I tried all the built-in variables but couldn't get the main domain name, so I added the `sld` variable

```yaml
patterns:
  - "{{sld}}.{{suffix}}" #
```
`something.scanme.sh` => SLD => `scanme`
