### PR TITLE
allow words to be in the template

### DIFF
--- a/mutator.go
+++ b/mutator.go
@@ -235,11 +235,12 @@ func (m *Mutator) clusterBomb(template string, results chan string) {
 	payloadSet := map[string][]string{}
 	// instead of sending all payloads only send payloads that are used
 	// in template/statement
+	leftmostSub := strings.Split(template, ".")[0]
 	for _, v := range varsUsed {
 		payloadSet[v] = []string{}
 		for _, word := range m.Options.Payloads[v] {
-			if !strings.Contains(template, word) {
-				// skip all words that are already present in template/sub , it is highly unlikely
+			if !strings.HasPrefix(leftmostSub, word) && !strings.HasSuffix(leftmostSub, word) {
+				// skip all words that are already present in leftmost sub , it is highly unlikely
 				// we will ever find api-api.example.com
 				payloadSet[v] = append(payloadSet[v], word)
 			}


### PR DESCRIPTION
This fixes #168 
The check `strings.Contains(template, word)` has lots of unintended consequences.
Examples:
`api-pizzapie.site.com` would not be allowed as `pizzapie` contains `api`
`site-api.site.com` would not be allowed as `site` is in the template `{{word}}-api.site.com`
`dev-api.site.dev` would not be allowed as `dev` is in the template `{{word}}-api.site.dev`

I thought about adding a command option or adding a more complex check but decided just removing it is better.
I don't think the optimization saves much anyway, DNS requests are cheap. 