### PR TITLE
replace gopkg.in/yaml.v3 to github.com/goccy/go-yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,9 @@ module github.com/projectdiscovery/alterx
 
 go 1.21
 
+
 require (
+	github.com/goccy/go-yaml v1.13.8
 	github.com/projectdiscovery/fasttemplate v0.0.2
 	github.com/projectdiscovery/goflags v0.1.64
 	github.com/projectdiscovery/gologger v1.1.31

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/goccy/go-yaml v1.13.8 h1:ftugzaplJyFaFwfyVNeq1XQOBxmlp8zazmuiobaCXbk=
+github.com/goccy/go-yaml v1.13.8/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/runner/config.go
+++ b/internal/runner/config.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/goccy/go-yaml"
 	"github.com/projectdiscovery/alterx"
 	"github.com/projectdiscovery/gologger"
 	fileutil "github.com/projectdiscovery/utils/file"
-	"gopkg.in/yaml.v3"
 )
 
 func getUserHomeDir() string {
@@ -29,6 +29,9 @@ func init() {
 			if errx := yaml.Unmarshal(bin, &cfg); errx == nil {
 				alterx.DefaultConfig = cfg
 				return
+			} else {
+				gologger.Error().Msgf("alterx yaml configuration syntax error.\n %v\n.", yaml.FormatError(errx, true, true))
+				os.Exit(1)
 			}
 		}
 	}


### PR DESCRIPTION
replace gopkg.in/yaml.v3 to github.com/goccy/go-yaml
Implement yaml syntax check, avoid roughly overwriting the incorrectly modified configuration files directly.

> Just simple modifications can be used as a reference

`$ alterx --version`
```
[INF] Current version: v0.0.4
```
`$ alterx --version`
```
[ERR] alterx yaml configuration syntax error.
 [24:5] required ':' and map value
  21 | payloads:
  22 |   word:
  23 |     - "api"
> 24 |   - "errortest"
           ^
  25 |     - "k8s"
  26 |     - "v1"
  27 |     - "v2"
.
```