### PR TITLE
Keep stdout when writing -o file

### DIFF
--- a/cmd/alterx/main.go
+++ b/cmd/alterx/main.go
@@ -13,8 +13,15 @@ func main() {
 
 	cliOpts := runner.ParseFlags()
 
-	// Write output with deduplication
-	output := getOutputWriter(cliOpts.Output)
+	output, closer, err := newOutputWriter(cliOpts.Output, os.Stdout)
+	if err != nil {
+		gologger.Fatal().Msgf("failed to open output file %v got %v", cliOpts.Output, err)
+	}
+	defer func() {
+		if cerr := closer.Close(); cerr != nil {
+			gologger.Error().Msgf("failed to close output file: %v", cerr)
+		}
+	}()
 
 	// Build alterx options with all modes supported
 	alterOpts := alterx.Options{
@@ -70,14 +77,14 @@ func main() {
 	}
 }
 
-// getOutputWriter returns the appropriate output writer
-func getOutputWriter(outputPath string) io.Writer {
-	if outputPath != "" {
-		fs, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-		if err != nil {
-			gologger.Fatal().Msgf("failed to open output file %v got %v", outputPath, err)
-		}
-		return fs
+// newOutputWriter writes results to stdout, and also to outputPath when set.
+func newOutputWriter(outputPath string, stdout io.Writer) (io.Writer, io.Closer, error) {
+	if outputPath == "" {
+		return stdout, io.NopCloser(nil), nil
 	}
-	return os.Stdout
+	fs, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+	return io.MultiWriter(stdout, fs), fs, nil
 }

--- a/cmd/alterx/main_test.go
+++ b/cmd/alterx/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewOutputWriterStdoutOnly(t *testing.T) {
+	var stdout bytes.Buffer
+	w, closer, err := newOutputWriter("", &stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if cerr := closer.Close(); cerr != nil {
+			t.Errorf("close: %v", cerr)
+		}
+	})
+
+	if _, err := w.Write([]byte("scanme.sh\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "scanme.sh\n" {
+		t.Fatalf("stdout = %q, want scanme.sh\\n", got)
+	}
+}
+
+func TestNewOutputWriterWritesStdoutAndFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.txt")
+	var stdout bytes.Buffer
+	w, closer, err := newOutputWriter(path, &stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := w.Write([]byte("one.example\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("two.example\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := stdout.String(); got != "one.example\ntwo.example\n" {
+		t.Fatalf("stdout = %q", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != "one.example\ntwo.example\n" {
+		t.Fatalf("file = %q", got)
+	}
+}
+
+func TestNewOutputWriterOpenError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-such-dir", "out.txt")
+	_, _, err := newOutputWriter(missing, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error opening nested missing directory")
+	}
+	if !strings.Contains(err.Error(), "no-such-dir") && !os.IsNotExist(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `-o` now writes results to stdout and the file, matching dnsx/subfinder/httpx/mapcidr
- Output file is closed after the run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Results can now be displayed in the terminal and saved to an output file simultaneously.
  * Added clear error reporting when the output file cannot be opened.

* **Bug Fixes**
  * Output files are properly closed after processing, with close errors reported when applicable.

* **Tests**
  * Added coverage for terminal-only output, combined terminal and file output, and invalid output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->